### PR TITLE
fix getPublicUrl

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1437,7 +1437,7 @@ function getPublicUrl(bucket, key, bucketLocation, endpoint) {
   var hostnamePrefix = nonStandardBucketLocation ? ("s3-" + bucketLocation) : "s3";
   var parts = {
     protocol: "https:",
-    hostname: hostnamePrefix + '.' + (endpoint || "amazonaws.com"),
+    hostname: (endpoint || "amazonaws.com"),
     pathname: "/" + bucket + "/" + encodeSpecialCharacters(key),
   };
   return url.format(parts);


### PR DESCRIPTION
when use getPublicUrl, hostname prefix was the same than endpoint, it make that the final url was something like this

https://s3-eu-west-1.s3-eu-west-1.amazonaws.com/mybucket/somefolder/whatever/1c55126efsdsfdsa.pdf

and the correct url should be 

https://s3-eu-west-1.amazonaws.com/mybucket/somefolder/whatever/1c55126efsdsfdsa.pdf